### PR TITLE
Set psql settings to defaults, and don't force a user

### DIFF
--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -6,7 +6,7 @@ failcount=0
 runcount=0
 testtotal=$(grep -c '^tf ' "$0")
 
-psqld="psql -q -U postgres -d testing_postgis_vt_util"
+psqld="psql -AtqX -d testing_postgis_vt_util"
 $psqld -f "$(dirname "$0")/../postgis-vt-util.sql" &> /dev/null
 
 function tf() {


### PR DESCRIPTION
A user might have a psqlrc file which sets non-default values, which
can cause problems for trying to parse the psql response. These
flags are suitable for parsing the results in a bash script

Avoid forcing a particular user. If a particular user is needed
this can be set with PGUSER