### PR TITLE
Rewrite Z function in plain SQL

### DIFF
--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -608,15 +608,16 @@ __Example Mapbox Studio query:__
 ******************************************************************************/
 create or replace function z (numeric)
   returns integer
-  language plpgsql immutable as
-$func$
-begin
+  language sql
+  immutable
+  returns null on null input
+as $func$
+select
+  case
     -- Don't bother if the scale is larger than ~zoom level 0
-    if $1 > 600000000 then
-        return null;
-    end if;
-    return round(log(2,559082264.028/$1));
-end;
+    when $1 > 600000000 or $1 = 0 then null
+    else cast (round(log(2,559082264.028/$1)) as integer)
+  end;
 $func$;
 
 

--- a/src/Z.sql
+++ b/src/Z.sql
@@ -23,15 +23,16 @@ __Example Mapbox Studio query:__
 ******************************************************************************/
 create or replace function z (numeric)
   returns integer
-  language plpgsql immutable as
-$func$
-begin
+  language sql
+  immutable
+  returns null on null input
+as $func$
+select
+  case
     -- Don't bother if the scale is larger than ~zoom level 0
-    if $1 > 600000000 then
-        return null;
-    end if;
-    return round(log(2,559082264.028/$1));
-end;
+    when $1 > 600000000 or $1 = 0 then null
+    else cast (round(log(2,559082264.028/$1)) as integer)
+  end;
 $func$;
 
 

--- a/test/sql-test.sh
+++ b/test/sql-test.sh
@@ -126,6 +126,7 @@ tf ToPoint "ST_GeomFromText('POLYGON((0 0, 10 0, 0 10, 10 10, 0 0))',900913)" \
 tf Z "1000000000" "\\N"
 tf Z "500000000" "0"
 tf Z "1000" "19"
+tf Z "0" "\\N"
 
 # ZRes
 tf ZRes "0" "156543.033928041"


### PR DESCRIPTION
Function call costs for SQL functions are **significantly** less than plpgsql. Also adds coverage for Z(0) test and `returns null on null input`