### PR TITLE
Search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v1.2.2
+------
+
+- Change queries to call functions with a specific schema.object form, for
+  objects that exist in the pg_catalog, to mitigate the search_path 
+  vulnerability.
+
 v1.2.1
 ------
 

--- a/postgis-vt-util.sql
+++ b/postgis-vt-util.sql
@@ -232,7 +232,7 @@ begin
         -- if length is 0 geom is (probably) a point; keep it
         return true;
     else
-        return length(label) between 1 and ST_Length(g)/(2^(20-zoom));
+        return pg_catalog.length(label) between 1 and ST_Length(g)/(2^(20-zoom));
     end if;
 end;
 $func$;
@@ -310,7 +310,7 @@ $func$
 begin
     return ST_Buffer(
         g,
-        distance / cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))))
+        distance / pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g),4326))))
     );
 end;
 $func$;
@@ -344,7 +344,7 @@ begin
     return ST_Dwithin(
         g1,
         g2,
-        distance / cos(radians(ST_Y(ST_Transform(ST_Centroid(g1),4326))))
+        distance / pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g1),4326))))
     );
 end;
 $func$;
@@ -368,7 +368,7 @@ create or replace function MercLength (g geometry)
     language plpgsql immutable as
 $func$
 begin
-    return ST_Length(g) * cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));
+    return ST_Length(g) * pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));
 end;
 $func$;
 
@@ -681,7 +681,7 @@ select
   case
     -- Don't bother if the scale is larger than ~zoom level 0
     when $1 > 600000000 or $1 = 0 then null
-    else cast (round(log(2,559082264.028/$1)) as integer)
+    else cast (pg_catalog.round(pg_catalog.log(2,559082264.028/$1)) as integer)
   end;
 $func$;
 

--- a/src/LineLabel.sql
+++ b/src/LineLabel.sql
@@ -28,7 +28,7 @@ begin
         -- if length is 0 geom is (probably) a point; keep it
         return true;
     else
-        return length(label) between 1 and ST_Length(g)/(2^(20-zoom));
+        return pg_catalog.length(label) between 1 and ST_Length(g)/(2^(20-zoom));
     end if;
 end;
 $func$;

--- a/src/MercBuffer.sql
+++ b/src/MercBuffer.sql
@@ -21,7 +21,7 @@ $func$
 begin
     return ST_Buffer(
         g,
-        distance / cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))))
+        distance / pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g),4326))))
     );
 end;
 $func$;

--- a/src/MercDWithin.sql
+++ b/src/MercDWithin.sql
@@ -26,7 +26,7 @@ begin
     return ST_Dwithin(
         g1,
         g2,
-        distance / cos(radians(ST_Y(ST_Transform(ST_Centroid(g1),4326))))
+        distance / pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g1),4326))))
     );
 end;
 $func$;

--- a/src/MercLength.sql
+++ b/src/MercLength.sql
@@ -16,7 +16,7 @@ create or replace function MercLength (g geometry)
     language plpgsql immutable as
 $func$
 begin
-    return ST_Length(g) * cos(radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));
+    return ST_Length(g) * pg_catalog.cos(pg_catalog.radians(ST_Y(ST_Transform(ST_Centroid(g),4326))));
 end;
 $func$;
 

--- a/src/Z.sql
+++ b/src/Z.sql
@@ -31,7 +31,7 @@ select
   case
     -- Don't bother if the scale is larger than ~zoom level 0
     when $1 > 600000000 or $1 = 0 then null
-    else cast (round(log(2,559082264.028/$1)) as integer)
+    else cast (pg_catalog.round(pg_catalog.log(2,559082264.028/$1)) as integer)
   end;
 $func$;
 


### PR DESCRIPTION
This PR is about calling the `pg_catalog` schema explicitly to protect the Database's Search Path as suggested by [PostgreSQL documentation](https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058:_Protect_Your_Search_Path#Impact:_Are_My_PostgreSQL_Installations_Affected.3F):

> If you write your queries with specific schema.object form, including objects that exist in the pg_catalog (e.g. calling SELECT pg_catalog.lower('ALICE');), then you are not immediately vulnerable to this issue.

